### PR TITLE
Update package to be compatible with R 4.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: R clients to the 'Web of Science' and 'InCites'
   indexed in the 'Web of Science' and 'InCites' databases.
 URL: https://vt-arc.github.io/wosr/index.html
 BugReports: https://github.com/vt-arc/wosr/issues
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: person("Christopher", "Baker", email = "chriscrewbaker@gmail.com",
   role = c("aut", "cre"))
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
   utils,
   tools,
   base64enc
-RoxygenNote: 6.1.0
+RoxygenNote: 7.2.3
 Suggests: 
   testthat,
   knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# wosr 0.3.1
+
+* Fixed issue with `pull_wos()` and associated function not working with R 4.3 (#26)
+* Updated test harness to use IP-based authentication when available
+
 # wosr 0.3.0
 
 ## New functions

--- a/R/enfore-schema.R
+++ b/R/enfore-schema.R
@@ -8,7 +8,7 @@ enforce_schema <- function(wos_unenforced) {
     # have to run these logical tests in wonky way b/c don't want warning about
     # is.na(NULL), etc
     df_has_no_rows <- if (is_df) nrow(maybe_df) == 0 else FALSE
-    na_or_empty <- if (!is_null) df_has_no_rows || is.na(maybe_df) else FALSE
+    na_or_empty <- if (!is_null) df_has_no_rows || all(is.na(maybe_df)) else FALSE
 
     df <- if (na_or_empty || is_null) make_df(name) else maybe_df
     cast_fields(df, name)

--- a/R/enfore-schema.R
+++ b/R/enfore-schema.R
@@ -8,7 +8,7 @@ enforce_schema <- function(wos_unenforced) {
     # have to run these logical tests in wonky way b/c don't want warning about
     # is.na(NULL), etc
     df_has_no_rows <- if (is_df) nrow(maybe_df) == 0 else FALSE
-    na_or_empty <- if (!is_null) df_has_no_rows || all(is.na(maybe_df)) else FALSE
+    na_or_empty <- if (!is_null) df_has_no_rows || any(is.na(maybe_df)) else FALSE
 
     df <- if (na_or_empty || is_null) make_df(name) else maybe_df
     cast_fields(df, name)

--- a/man/auth.Rd
+++ b/man/auth.Rd
@@ -4,8 +4,10 @@
 \alias{auth}
 \title{Authenticate user credentials}
 \usage{
-auth(username = Sys.getenv("WOS_USERNAME"),
-  password = Sys.getenv("WOS_PASSWORD"))
+auth(
+  username = Sys.getenv("WOS_USERNAME"),
+  password = Sys.getenv("WOS_PASSWORD")
+)
 }
 \arguments{
 \item{username}{Your username. Specify \code{username = NULL} if you want to

--- a/man/pull_cited_refs.Rd
+++ b/man/pull_cited_refs.Rd
@@ -4,8 +4,11 @@
 \alias{pull_cited_refs}
 \title{Pull cited references}
 \usage{
-pull_cited_refs(uts, sid = auth(Sys.getenv("WOS_USERNAME"),
-  Sys.getenv("WOS_PASSWORD")), ...)
+pull_cited_refs(
+  uts,
+  sid = auth(Sys.getenv("WOS_USERNAME"), Sys.getenv("WOS_PASSWORD")),
+  ...
+)
 }
 \arguments{
 \item{uts}{Vector of UTs (i.e., publications) whose cited references you want.}

--- a/man/pull_related_recs.Rd
+++ b/man/pull_related_recs.Rd
@@ -4,10 +4,14 @@
 \alias{pull_related_recs}
 \title{Pull related records}
 \usage{
-pull_related_recs(uts, num_recs, editions = c("SCI", "SSCI", "AHCI",
-  "ISTP", "ISSHP", "BSCI", "BHCI", "IC", "CCR", "ESCI"),
+pull_related_recs(
+  uts,
+  num_recs,
+  editions = c("SCI", "SSCI", "AHCI", "ISTP", "ISSHP", "BSCI", "BHCI", "IC", "CCR",
+    "ESCI"),
   sid = auth(Sys.getenv("WOS_USERNAME"), Sys.getenv("WOS_PASSWORD")),
-  ...)
+  ...
+)
 }
 \arguments{
 \item{uts}{The documents whose related records you want to pull.}

--- a/man/pull_wos.Rd
+++ b/man/pull_wos.Rd
@@ -4,10 +4,13 @@
 \alias{pull_wos}
 \title{Pull data from the Web of Science}
 \usage{
-pull_wos(query, editions = c("SCI", "SSCI", "AHCI", "ISTP", "ISSHP",
-  "BSCI", "BHCI", "IC", "CCR", "ESCI"),
+pull_wos(
+  query,
+  editions = c("SCI", "SSCI", "AHCI", "ISTP", "ISSHP", "BSCI", "BHCI", "IC", "CCR",
+    "ESCI"),
   sid = auth(Sys.getenv("WOS_USERNAME"), Sys.getenv("WOS_PASSWORD")),
-  ...)
+  ...
+)
 }
 \arguments{
 \item{query}{Query string. See the \href{https://images.webofknowledge.com/images/help/WOK/hs_search_operators.html#dsy863-TRS_search_operator_precedence}{WoS query documentation} page
@@ -80,10 +83,10 @@ sid <- auth("your_username", password = "your_password")
 pull_wos("TS = (dog welfare) AND PY = 2010", sid = sid)
 
 # Re-use session ID. This is best practice to avoid throttling limits:
-pull_wos("TI = \\"dog welfare\\"", sid = sid)
+pull_wos("TI = \"dog welfare\"", sid = sid)
 
 # Get fresh session ID:
-pull_wos("TI = \\"pet welfare\\"", sid = auth("your_username", "your_password"))
+pull_wos("TI = \"pet welfare\"", sid = auth("your_username", "your_password"))
 
 # It's best to see how many records your query matches before actually
 # downloading the data. To do this, call query_wos before running pull_wos:

--- a/man/pull_wos_apply.Rd
+++ b/man/pull_wos_apply.Rd
@@ -4,10 +4,13 @@
 \alias{pull_wos_apply}
 \title{Run \code{pull_wos} across multiple queries}
 \usage{
-pull_wos_apply(queries, editions = c("SCI", "SSCI", "AHCI", "ISTP",
-  "ISSHP", "BSCI", "BHCI", "IC", "CCR", "ESCI"),
+pull_wos_apply(
+  queries,
+  editions = c("SCI", "SSCI", "AHCI", "ISTP", "ISSHP", "BSCI", "BHCI", "IC", "CCR",
+    "ESCI"),
   sid = auth(Sys.getenv("WOS_USERNAME"), Sys.getenv("WOS_PASSWORD")),
-  ...)
+  ...
+)
 }
 \arguments{
 \item{queries}{Vector of queries to issue to the WoS API and pull data for.}

--- a/man/query_wos.Rd
+++ b/man/query_wos.Rd
@@ -4,10 +4,13 @@
 \alias{query_wos}
 \title{Query the Web of Science}
 \usage{
-query_wos(query, editions = c("SCI", "SSCI", "AHCI", "ISTP", "ISSHP",
-  "BSCI", "BHCI", "IC", "CCR", "ESCI"),
+query_wos(
+  query,
+  editions = c("SCI", "SSCI", "AHCI", "ISTP", "ISSHP", "BSCI", "BHCI", "IC", "CCR",
+    "ESCI"),
   sid = auth(Sys.getenv("WOS_USERNAME"), Sys.getenv("WOS_PASSWORD")),
-  ...)
+  ...
+)
 }
 \arguments{
 \item{query}{Query string. See the \href{https://images.webofknowledge.com/images/help/WOK/hs_search_operators.html#dsy863-TRS_search_operator_precedence}{WoS query documentation} page
@@ -40,7 +43,7 @@ many records you're trying to download before attempting to do so.
 # Get session ID and reuse it across queries:
 sid <- auth("some_username", password = "some_password")
 
-query_wos("TS = (\\"dog welfare\\") AND PY = (1990-2007)", sid = sid)
+query_wos("TS = (\"dog welfare\") AND PY = (1990-2007)", sid = sid)
 
 # Finds records in which Max Planck appears in the address field.
 query_wos("AD = Max Planck", sid = sid)

--- a/man/query_wos_apply.Rd
+++ b/man/query_wos_apply.Rd
@@ -4,10 +4,13 @@
 \alias{query_wos_apply}
 \title{Run \code{query_wos} across multiple queries}
 \usage{
-query_wos_apply(queries, editions = c("SCI", "SSCI", "AHCI", "ISTP",
-  "ISSHP", "BSCI", "BHCI", "IC", "CCR", "ESCI"),
+query_wos_apply(
+  queries,
+  editions = c("SCI", "SSCI", "AHCI", "ISTP", "ISSHP", "BSCI", "BHCI", "IC", "CCR",
+    "ESCI"),
   sid = auth(Sys.getenv("WOS_USERNAME"), Sys.getenv("WOS_PASSWORD")),
-  ...)
+  ...
+)
 }
 \arguments{
 \item{queries}{Vector of queries run.}

--- a/man/wosr.Rd
+++ b/man/wosr.Rd
@@ -3,8 +3,4 @@
 \docType{package}
 \name{wosr}
 \alias{wosr}
-\alias{wosr-package}
 \title{wosr}
-\description{
-wosr
-}

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,6 +1,13 @@
 # Taken from https://cran.r-project.org/web/packages/httr/vignettes/secrets.html
 skip_if_no_auth <- function() {
-  if (identical(Sys.getenv("WOS_USERNAME"), "")) {
+  if (!exists("sid")) {
+    sid_try <- try(auth(username = NULL, password = NULL), silent = TRUE)
+    if (class(sid_try) != "try-error") {
+      assign("sid", sid_try, envir = .GlobalEnv)
+    }
+  }
+
+  if (identical(Sys.getenv("WOS_USERNAME"), "") && class(sid) == "try-error") {
     skip("No authentication available")
   }
 }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -7,7 +7,7 @@ skip_if_no_auth <- function() {
     }
   }
 
-  if (identical(Sys.getenv("WOS_USERNAME"), "") && class(sid) == "try-error") {
+  if (identical(Sys.getenv("WOS_USERNAME"), "") && class(sid_try) == "try-error") {
     skip("No authentication available")
   }
 }

--- a/tests/testthat/test-wos.R
+++ b/tests/testthat/test-wos.R
@@ -4,7 +4,6 @@ test_that("authentication works", {
   skip_if_no_auth()
   # reuse sid across tests, so we don't run into throttling limits. note that
   # this has to be inside test_that function so we can use skip_if_no_auth()
-  print(exists("sid"))
   if (!exists("sid")) sid <<- auth()
   expect_true(is.character(sid))
 })

--- a/tests/testthat/test-wos.R
+++ b/tests/testthat/test-wos.R
@@ -4,7 +4,8 @@ test_that("authentication works", {
   skip_if_no_auth()
   # reuse sid across tests, so we don't run into throttling limits. note that
   # this has to be inside test_that function so we can use skip_if_no_auth()
-  sid <<- auth()
+  print(exists("sid"))
+  if (!exists("sid")) sid <<- auth()
   expect_true(is.character(sid))
 })
 


### PR DESCRIPTION
Fixes #26.

I had to make some tweaks to the test harness to let it use IP-based auth, because that's all I have access to. 

The test "pull_cited_refs returns data for pubs with cited refs" is failing for me, because it returns no data. I'm not 100% sure if this is because of a limitation of my API key, something to do with the specific journal for those publications, or something else. I am confident it has nothing to do with this PR though - the `pull_cited_refs()` works fine for other UTs.